### PR TITLE
MIRSCR-1288-revert-ignore-table-migrations

### DIFF
--- a/recipe/db.php
+++ b/recipe/db.php
@@ -8,7 +8,8 @@ set('db_source_mode', 'current');
 
 function inflateDb($type='') {
     $dbSourceMode = get('db_source_mode');
-    $excludeMigrationTable = $type==='repipe' ? ' --ignore-table=migrations ' : '';
+    $excludeMigrationTable = '';
+    // $excludeMigrationTable = $type==='repipe' ? ' --ignore-table=migrations ' : '';
     switch ($dbSourceMode) {
         case 'current':
             $condition = get('db_name_previous');


### PR DESCRIPTION
https://mir24tv.atlassian.net/browse/MIRSCR-1288

Примерно 5% миграций лучше вызывать повторно. Но 50% миграций отработают неправильно, если их вызвать повторно. Так что отменяем и пишем миграции с учётом двойного выполнения