### PR TITLE
Default timeout set 3600

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -42,7 +42,7 @@ set('rsync', [
 
 set('ssh_multiplexing', true);
 
-set('default_timeout', 1800);
+set('default_timeout', 3600);
 set('copy_dirs', ['vendor']);
 
 // Project name
@@ -294,7 +294,7 @@ task('npm:install', function () {
             writeln('<info>Packages installation may take a while for the first time..</info>');
         }
     }
-    run('cd {{release_path}} && {{bin/npm}} install', ['timeout' => 1800]);
+    run('cd {{release_path}} && {{bin/npm}} install');
 })->onRoles(
     ROLE_FS,
     ROLE_BC,
@@ -304,12 +304,12 @@ task('npm:install', function () {
 //TODO Try to copy tsd indtallation from previous release
 desc('Install tsd packages');
 task('tsd:install', function () {
-    run('cd {{release_path}} && {{bin/npm}} run tsd -- install', ['timeout' => 1800]);
+    run('cd {{release_path}} && {{bin/npm}} run tsd -- install');
 })->onRoles(ROLE_PB);
 
 desc('Build npm packages');
 task('npm:build', function () {
-    run('cd {{release_path}} && {{bin/npm}} run build', ['timeout' => 1800]);
+    run('cd {{release_path}} && {{bin/npm}} run build');
 })->onRoles(
     ROLE_FS,
     ROLE_BC,


### PR DESCRIPTION
Евгений Лебедев, [30.06.20 12:37]
Trying to inflate database mir24_dep_20200630_1129 with release data from mir24_dep_20200603_1308, please wait..

In Process.php line 1335:
                                                                                                                                                                                                                         
  The process "ssh -A -o ControlMaster=auto -o ControlPersist=60 -o ControlPath=~/.ssh/deployer_deploy@dev.mir24.int -o StrictHostKeyChecking=no deploy@dev.mir24.int  'bash -s; printf "[exit_code:%s]" $?;'" exceeded  
   the timeout of 1800 seconds.

Евгений Лебедев, [30.06.20 17:09]
deploy.php:set('default_timeout', 1800);
deploy.php:    run('cd {{release_path}} && {{bin/npm}} install', ['timeout' => 1800]);
deploy.php:    run('cd {{release_path}} && {{bin/npm}} run tsd -- install', ['timeout' => 1800]);
deploy.php:    run('cd {{release_path}} && {{bin/npm}} run build', ['timeout' => 1800]);

Предлагаю увеличить дефолтный.

Евгений Лебедев, [30.06.20 17:13]
ок, без сброса кэшей - увеличиваем таймаут с 1800 до 3000, чтобы ошибка гарантированно не повторилась.